### PR TITLE
GitHub Actionsを利用した図の更新

### DIFF
--- a/.github/workflows/figures_update.yaml
+++ b/.github/workflows/figures_update.yaml
@@ -1,39 +1,30 @@
 on:
   schedule:
-    - cron:  '48 */6 * * *'
+    - cron:  '48 */9 * * *'
 
 name: Figures Update
 
 jobs:
   render:
     name: Figures Update
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v2
       - uses: r-lib/actions/setup-r@v1
-
-      - name: Install font on ubuntu
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends fonts-ipaexfont curl libcurl4-openssl-dev libudunits2-dev libgdal-dev libgeos-dev libproj-dev
-
       - uses: actions/cache@v1
-        if: startsWith(runner.os, 'Linux')
+        if: startsWith(runner.os, 'macOS')
         with:
-          path: ~/.local/share/renv
+          path: ~/Library/Application Support/renv
           key: ${{ runner.os }}-renv-${{ hashFiles('**/renv.lock') }}
           restore-keys: |
             ${{ runner.os }}-renv-
-      
       - name: Install Package Dependencies
         run: |-
           Rscript -e "install.packages('renv'); renv::restore(confirm = FALSE)"
       - name: 
         run: |
           Rscript -e 'source("mapping.R")'
-
       - name: Commit results
         run: |
-          git add figures/*
           git commit figures/* -m 'Update' || echo "No changes to commit"
           git push https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:${{ github.ref }} || echo "No changes to commit"

--- a/mapping.R
+++ b/mapping.R
@@ -17,9 +17,11 @@ library(patchwork)
 library(readxl)
 library(drake)
 library(nord)
-download.file(
-  "https://www.e-stat.go.jp/stat-search/file-download?statInfId=000031807141&fileKind=0",
-  destfile = "data-raw/2018h30_a00400.xls")
+if (!file.exists("data-raw/2018h30_a00400.xls")) {
+  download.file(
+    "https://www.e-stat.go.jp/stat-search/file-download?statInfId=000031807141&fileKind=0",
+    destfile = "data-raw/2018h30_a00400.xls")
+}
 plan_data <- 
   drake::drake_plan(
     df_pop_201810 =
@@ -186,9 +188,7 @@ p1_a + p1_b +
     subtitle = "1) Residence of infected people",
     caption = plot_caps$caption)
 ggsave(last_plot(),
-       filename = glue::glue("figures/{datetime}_prefecture_count.png",
-                             datetime = stringr::str_replace(as.character(data_lastupdate), " ", "_") %>% 
-                               stringr::str_replace_all(":", "")),
+       filename = "figures/latest_prefecture_count.png",
        width = 10,
        height = 8)
 
@@ -200,9 +200,6 @@ p2_a + p2_b +
     subtitle = "2) Ratio of population to residence of infected people",
     caption = plot_caps$caption)
 ggsave(last_plot(),
-       filename = path2prefecture_population_ratio,
+       filename = "figures/latest_prefecture_population_ratio.png",
        width = 10,
        height = 8)
-file.copy(path2prefecture_population_ratio,
-          "figures/latest_prefecture_population_ratio.png", 
-          overwrite = TRUE)


### PR DESCRIPTION
## Summary

- #2 への対応。CRONスケジュールを仕込み、`figures/` のファイルを自動更新する。
    - 現在の設定は `'48 */9 * * *'`
    - ファイル名にタイムスタンプを含めていたが、最新のファイルだけをコミットするように変更（履歴は見れるので）
- 日本語フォントを使った出力を試みたが失敗。フォントのインストールはできるものの、`ggsave()`を行う際にエラーとなる。
- GitHub へのpushはGitHub Actionsの実行OSをmacOSにしないとダメだった。ただgit configで与えればできそうではある。

## Related issues

Close #2 